### PR TITLE
Improve packaging, tests, and documentation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
+        pip install -e .
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,45 @@
 # Crown CNC Estimator
 
-This repository provides minimal utilities for estimating CNC runtime and
-parsing STEP models. The project currently includes a small test suite
-based on `pytest` and a sample STEP file in `tests/`.
+Utilities for estimating CNC runtime and parsing STEP models.
+The package can be installed in editable mode for development or as a
+standard dependency.
+
+```bash
+pip install -e .
+```
+
+This installs the ``crown-cnc-estimator`` command-line interface.
+
+The project includes a test suite based on `pytest` and a sample STEP file
+in `tests/`.
+
+## Usage
+
+Calculate runtime:
+
+```python
+from crown_cnc_estimator import calculate_runtime
+
+runtime = calculate_runtime(feed_rate=100, path_length=200)
+print(runtime)  # 2.0 minutes
+```
+
+Parse a STEP file:
+
+```python
+from pathlib import Path
+from crown_cnc_estimator import parse_step
+
+count = parse_step(Path("example.step"))
+print(count)
+```
+
+The CLI can compute a bounding box for a STEP file and round dimensions up to
+the nearest 0.125&nbsp;inch (3.175&nbsp;mm). Units and material can be selected:
+
+```bash
+crown-cnc-estimator tests/sample.step --units inch --material 1018
+```
 
 ## Running Tests
 

--- a/crown_cnc_estimator/__init__.py
+++ b/crown_cnc_estimator/__init__.py
@@ -1,0 +1,8 @@
+"""Top-level package for Crown CNC Estimator."""
+
+from .runtime import calculate_runtime
+from .step_parser import parse_step, bounding_box
+
+APP_NAME = "Crown CNC Estimator"
+__all__ = ["calculate_runtime", "parse_step", "bounding_box", "APP_NAME"]
+__version__ = "0.1.0"

--- a/crown_cnc_estimator/cli.py
+++ b/crown_cnc_estimator/cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .step_parser import bounding_box
+from . import APP_NAME
+
+INCH_INC = 0.125
+MM_INC = 3.175  # 0.125 inch in mm
+
+MATERIALS = {
+    "6061": "6061 aluminum",
+    "1018": "1018 steel",
+    "304": "304 stainless",
+}
+
+def round_up(value: float, increment: float) -> float:
+    """Round ``value`` up to the nearest multiple of ``increment``."""
+    import math
+    return math.ceil(value / increment) * increment
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=f"{APP_NAME} CLI")
+    parser.add_argument("file", type=Path, help="STEP file to analyze")
+    parser.add_argument(
+        "--units",
+        choices=["metric", "inch"],
+        default="metric",
+        help="Units used in the STEP file",
+    )
+    parser.add_argument(
+        "--material",
+        choices=list(MATERIALS),
+        default="6061",
+        help="Material type",
+    )
+    args = parser.parse_args(argv)
+
+    bb = bounding_box(args.file)
+    min_x, min_y, min_z, max_x, max_y, max_z = bb
+    dims = (max_x - min_x, max_y - min_y, max_z - min_z)
+
+    increment = INCH_INC if args.units == "inch" else MM_INC
+    rounded_dims = tuple(round_up(d, increment) for d in dims)
+
+    print(f"Material: {MATERIALS[args.material]}")
+    print(f"Units: {args.units}")
+    print(f"Bounding box: {rounded_dims[0]} x {rounded_dims[1]} x {rounded_dims[2]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crown_cnc_estimator/step_parser.py
+++ b/crown_cnc_estimator/step_parser.py
@@ -1,5 +1,11 @@
 """STEP file parsing utilities."""
+
+from __future__ import annotations
+
 from pathlib import Path
+import re
+
+_COORD_PATTERN = re.compile(r"\((-?\d*\.?\d+),\s*(-?\d*\.?\d+),\s*(-?\d*\.?\d+)")
 
 
 def parse_step(file_path: Path | str) -> int:
@@ -11,3 +17,21 @@ def parse_step(file_path: Path | str) -> int:
             if line.strip().startswith("#"):
                 count += 1
     return count
+
+
+def bounding_box(file_path: Path | str) -> tuple[float, float, float, float, float, float]:
+    """Return (min_x, min_y, min_z, max_x, max_y, max_z) of coordinates found."""
+    path = Path(file_path)
+    xs: list[float] = []
+    ys: list[float] = []
+    zs: list[float] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            match = _COORD_PATTERN.search(line)
+            if match:
+                xs.append(float(match.group(1)))
+                ys.append(float(match.group(2)))
+                zs.append(float(match.group(3)))
+    if not xs:
+        raise ValueError("No coordinate triples found in STEP file")
+    return min(xs), min(ys), min(zs), max(xs), max(ys), max(zs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,12 @@ authors = [
 description = "Utilities for estimating CNC runtime and parsing STEP models"
 readme = "README.md"
 requires-python = ">=3.8"
-packages = ["crown_cnc_estimator"]
 
 [project.scripts]
 crown-cnc-estimator = "crown_cnc_estimator.cli:main"
 
 [project.urls]
 Homepage = "https://example.com"
+
+[tool.setuptools]
+packages = ["crown_cnc_estimator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "crown-cnc-estimator"
+version = "0.1.0"
+authors = [
+    {name = "Crown CNC"}
+]
+description = "Utilities for estimating CNC runtime and parsing STEP models"
+readme = "README.md"
+requires-python = ">=3.8"
+packages = ["crown_cnc_estimator"]
+
+[project.scripts]
+crown-cnc-estimator = "crown_cnc_estimator.cli:main"
+
+[project.urls]
+Homepage = "https://example.com"

--- a/tests/test_bounding_box.py
+++ b/tests/test_bounding_box.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from crown_cnc_estimator.step_parser import bounding_box
+
+
+def test_bounding_box_sample_metric():
+    sample = Path(__file__).parent / "sample.step"
+    bb = bounding_box(sample)
+    assert bb == (0.0, 0.0, 0.0, 1.0, 0.0, 1.0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_cli_runs(tmp_path):
+    sample = Path(__file__).parent / "sample.step"
+    cmd = [sys.executable, "-m", "crown_cnc_estimator.cli", str(sample), "--units", "inch", "--material", "1018"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Material: 1018 steel" in result.stdout

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,6 +1,7 @@
 import pytest
 
 from crown_cnc_estimator.runtime import calculate_runtime
+from crown_cnc_estimator import APP_NAME
 
 
 def test_calculate_runtime_basic():
@@ -12,3 +13,12 @@ def test_calculate_runtime_zero_feed_rate():
 
 def test_calculate_runtime_zero_path_length():
     assert calculate_runtime(100, 0) == 0
+
+
+def test_calculate_runtime_negative_path_length():
+    result = calculate_runtime(100, -50)
+    assert result == -0.5
+
+
+def test_app_name_constant():
+    assert APP_NAME == "Crown CNC Estimator"

--- a/tests/test_step_parsing.py
+++ b/tests/test_step_parsing.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import pytest
 
 from crown_cnc_estimator.step_parser import parse_step
 
@@ -6,3 +7,19 @@ from crown_cnc_estimator.step_parser import parse_step
 def test_parse_sample_step():
     sample = Path(__file__).parent / "sample.step"
     assert parse_step(sample) == 5
+
+
+def test_parse_step_missing_file():
+    missing = Path("non_existent.step")
+    with pytest.raises(FileNotFoundError):
+        parse_step(missing)
+
+
+def test_parse_large_step(tmp_path: Path):
+    sample = Path(__file__).parent / "sample.step"
+    data = sample.read_text()
+    large_file = tmp_path / "large.step"
+    # create a larger file by repeating the data 10 times
+    large_file.write_text(data * 10)
+    expected_count = 5 * 10
+    assert parse_step(large_file) == expected_count


### PR DESCRIPTION
## Summary
- package project via `pyproject.toml`
- expose public API and version in `__init__`
- extend tests to cover more cases
- document installation and basic usage
- install package in CI
- ignore caches
- add CLI utilities for bounding boxes with unit and material selection
- rename CLI script to `crown-cnc-estimator` and define an `APP_NAME` constant

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2dc68920832c8bcac873cbe671ad