### PR TITLE
Add Streamlit interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,32 @@ count = parse_step(Path("example.step"))
 print(count)
 ```
 
-The CLI can compute a bounding box for a STEP file and round dimensions up to
-the nearest 0.125&nbsp;inch (3.175&nbsp;mm). Units and material can be selected:
+The CLI now organizes features into subcommands.
+Compute a bounding box with rounding to the nearest 0.125&nbsp;inch
+(3.175&nbsp;mm):
 
 ```bash
-crown-cnc-estimator tests/sample.step --units inch --material 1018
+crown-cnc-estimator bounding-box tests/sample.step --units inch --material 1018
+```
+
+Other available subcommands are:
+
+```bash
+crown-cnc-estimator parse-step tests/sample.step
+crown-cnc-estimator runtime 100 200
+```
+
+Run interactively to be prompted for arguments, or launch a small GUI:
+
+```bash
+crown-cnc-estimator interactive
+crown-cnc-estimator gui
+```
+
+For a web-based interface, install `streamlit` and run the provided app:
+
+```bash
+streamlit run streamlit_app.py
 ```
 
 ## Running Tests

--- a/crown_cnc_estimator/cli.py
+++ b/crown_cnc_estimator/cli.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 
-from .step_parser import bounding_box
+from .step_parser import bounding_box, parse_step
+from .runtime import calculate_runtime
 from . import APP_NAME
 
 INCH_INC = 0.125
@@ -20,34 +22,137 @@ def round_up(value: float, increment: float) -> float:
     import math
     return math.ceil(value / increment) * increment
 
-
-def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description=f"{APP_NAME} CLI")
-    parser.add_argument("file", type=Path, help="STEP file to analyze")
-    parser.add_argument(
-        "--units",
-        choices=["metric", "inch"],
-        default="metric",
-        help="Units used in the STEP file",
-    )
-    parser.add_argument(
-        "--material",
-        choices=list(MATERIALS),
-        default="6061",
-        help="Material type",
-    )
-    args = parser.parse_args(argv)
-
+def _bounding_box_cmd(args: argparse.Namespace) -> None:
+    if not args.file.exists():
+        sys.exit(f"File not found: {args.file}")
     bb = bounding_box(args.file)
     min_x, min_y, min_z, max_x, max_y, max_z = bb
     dims = (max_x - min_x, max_y - min_y, max_z - min_z)
 
     increment = INCH_INC if args.units == "inch" else MM_INC
-    rounded_dims = tuple(round_up(d, increment) for d in dims)
+    rounded = tuple(round_up(d, increment) for d in dims)
 
     print(f"Material: {MATERIALS[args.material]}")
     print(f"Units: {args.units}")
-    print(f"Bounding box: {rounded_dims[0]} x {rounded_dims[1]} x {rounded_dims[2]}")
+    print("Bounding box:")
+    print(f"  X: {rounded[0]}")
+    print(f"  Y: {rounded[1]}")
+    print(f"  Z: {rounded[2]}")
+
+
+def _parse_cmd(args: argparse.Namespace) -> None:
+    if not args.file.exists():
+        sys.exit(f"File not found: {args.file}")
+    count = parse_step(args.file)
+    print(f"Entities: {count}")
+
+
+def _runtime_cmd(args: argparse.Namespace) -> None:
+    try:
+        runtime = calculate_runtime(args.feed_rate, args.path_length)
+    except ValueError as exc:
+        sys.exit(str(exc))
+    print(f"Estimated runtime: {runtime} minutes")
+
+
+def _interactive_cmd(_: argparse.Namespace) -> None:
+    file_path = Path(input("STEP file path: ").strip())
+    while not file_path.exists():
+        print("File does not exist. Try again.")
+        file_path = Path(input("STEP file path: ").strip())
+
+    units = input("Units (metric/inch) [metric]: ").strip() or "metric"
+    while units not in {"metric", "inch"}:
+        print("Units must be 'metric' or 'inch'.")
+        units = input("Units (metric/inch) [metric]: ").strip() or "metric"
+
+    material = input("Material (6061/1018/304) [6061]: ").strip() or "6061"
+    while material not in MATERIALS:
+        print(f"Material must be one of: {', '.join(MATERIALS)}")
+        material = input("Material (6061/1018/304) [6061]: ").strip() or "6061"
+
+    _bounding_box_cmd(argparse.Namespace(file=file_path, units=units, material=material))
+
+
+def _gui_cmd(_: argparse.Namespace) -> None:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox, ttk
+
+    def browse() -> None:
+        path = filedialog.askopenfilename(title="Select STEP file")
+        if path:
+            file_var.set(path)
+
+    def compute() -> None:
+        fp = Path(file_var.get())
+        if not fp.exists():
+            messagebox.showerror("Error", "File does not exist")
+            return
+        args = argparse.Namespace(file=fp, units=units_var.get(), material=mat_var.get())
+        try:
+            bb = bounding_box(fp)
+        except Exception as exc:  # pragma: no cover - GUI errors
+            messagebox.showerror("Error", str(exc))
+            return
+        min_x, min_y, min_z, max_x, max_y, max_z = bb
+        dims = (max_x - min_x, max_y - min_y, max_z - min_z)
+        increment = INCH_INC if args.units == "inch" else MM_INC
+        rounded = tuple(round_up(d, increment) for d in dims)
+        msg = (
+            f"Material: {MATERIALS[args.material]}\n"
+            f"Units: {args.units}\n"
+            f"Bounding box:\n  X: {rounded[0]}\n  Y: {rounded[1]}\n  Z: {rounded[2]}"
+        )
+        messagebox.showinfo("Result", msg)
+
+    root = tk.Tk()
+    root.title(APP_NAME)
+
+    tk.Label(root, text="STEP File:").grid(row=0, column=0, sticky="w")
+    file_var = tk.StringVar()
+    tk.Entry(root, textvariable=file_var, width=40).grid(row=0, column=1)
+    tk.Button(root, text="Browse", command=browse).grid(row=0, column=2)
+
+    tk.Label(root, text="Units:").grid(row=1, column=0, sticky="w")
+    units_var = tk.StringVar(value="metric")
+    ttk.Combobox(root, textvariable=units_var, values=["metric", "inch"], state="readonly").grid(row=1, column=1)
+
+    tk.Label(root, text="Material:").grid(row=2, column=0, sticky="w")
+    mat_var = tk.StringVar(value="6061")
+    ttk.Combobox(root, textvariable=mat_var, values=list(MATERIALS)).grid(row=2, column=1)
+
+    tk.Button(root, text="Compute", command=compute).grid(row=3, column=1)
+    root.mainloop()
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description=f"{APP_NAME} CLI",
+        epilog="Examples:\n  crown-cnc-estimator bounding-box sample.step --units inch --material 1018",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bb_parser = subparsers.add_parser("bounding-box", help="Compute bounding box for a STEP file")
+    bb_parser.add_argument("file", type=Path, help="STEP file to analyze")
+    bb_parser.add_argument("--units", choices=["metric", "inch"], default="metric", help="Units used in the STEP file")
+    bb_parser.add_argument("--material", choices=list(MATERIALS), default="6061", help="Material type")
+    bb_parser.set_defaults(func=_bounding_box_cmd)
+
+    parse_parser = subparsers.add_parser("parse-step", help="Count entries in a STEP file")
+    parse_parser.add_argument("file", type=Path, help="STEP file to parse")
+    parse_parser.set_defaults(func=_parse_cmd)
+
+    runtime_parser = subparsers.add_parser("runtime", help="Calculate runtime from feed rate and path length")
+    runtime_parser.add_argument("feed_rate", type=float, help="Feed rate (units/min)")
+    runtime_parser.add_argument("path_length", type=float, help="Path length (units)")
+    runtime_parser.set_defaults(func=_runtime_cmd)
+
+    subparsers.add_parser("interactive", help="Interactive bounding box prompts").set_defaults(func=_interactive_cmd)
+    subparsers.add_parser("gui", help="Launch graphical interface").set_defaults(func=_gui_cmd)
+
+    args = parser.parse_args(argv)
+    args.func(args)
 
 
 if __name__ == "__main__":

--- a/crown_cnc_estimator/step_parser.py
+++ b/crown_cnc_estimator/step_parser.py
@@ -12,7 +12,10 @@ def parse_step(file_path: Path | str) -> int:
     """Return the number of data entries in the given STEP file."""
     path = Path(file_path)
     count = 0
-    with path.open("r", encoding="utf-8") as f:
+    # STEP files are typically plain text, but some models may include
+    # non-UTF-8 characters. Ignore decode errors so such files can still be
+    # processed without raising ``UnicodeDecodeError``.
+    with path.open("r", encoding="utf-8", errors="ignore") as f:
         for line in f:
             if line.strip().startswith("#"):
                 count += 1
@@ -25,7 +28,9 @@ def bounding_box(file_path: Path | str) -> tuple[float, float, float, float, flo
     xs: list[float] = []
     ys: list[float] = []
     zs: list[float] = []
-    with path.open("r", encoding="utf-8") as f:
+    # Use ``errors='ignore'`` so files with a different encoding don't cause
+    # a failure when reading.
+    with path.open("r", encoding="utf-8", errors="ignore") as f:
         for line in f:
             match = _COORD_PATTERN.search(line)
             if match:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,65 @@
+import streamlit as st
+from pathlib import Path
+
+from crown_cnc_estimator.runtime import calculate_runtime
+from crown_cnc_estimator.step_parser import bounding_box, parse_step
+from crown_cnc_estimator.cli import MATERIALS, INCH_INC, MM_INC, round_up
+
+st.title("Crown CNC Estimator")
+
+mode = st.sidebar.selectbox(
+    "Select mode",
+    ("Bounding Box", "Parse STEP", "Runtime"),
+)
+
+if mode == "Bounding Box":
+    st.header("Bounding Box")
+    file = st.file_uploader("STEP file")
+    units = st.selectbox("Units", ["metric", "inch"], index=0)
+    material = st.selectbox("Material", list(MATERIALS), index=0)
+    if file and st.button("Compute"):
+        path = Path("uploaded.step")
+        with path.open("wb") as f:
+            f.write(file.getvalue())
+        try:
+            bb = bounding_box(path)
+        except Exception as exc:
+            st.error(str(exc))
+        else:
+            min_x, min_y, min_z, max_x, max_y, max_z = bb
+            dims = (max_x - min_x, max_y - min_y, max_z - min_z)
+            increment = INCH_INC if units == "inch" else MM_INC
+            rounded = tuple(round_up(d, increment) for d in dims)
+            st.text(f"Material: {MATERIALS[material]}")
+            st.text(f"Units: {units}")
+            st.text(f"Bounding box:\n  X: {rounded[0]}\n  Y: {rounded[1]}\n  Z: {rounded[2]}")
+        finally:
+            path.unlink(missing_ok=True)
+
+elif mode == "Parse STEP":
+    st.header("Parse STEP")
+    file = st.file_uploader("STEP file")
+    if file and st.button("Parse"):
+        path = Path("uploaded.step")
+        with path.open("wb") as f:
+            f.write(file.getvalue())
+        try:
+            count = parse_step(path)
+        except Exception as exc:
+            st.error(str(exc))
+        else:
+            st.text(f"Entities: {count}")
+        finally:
+            path.unlink(missing_ok=True)
+
+elif mode == "Runtime":
+    st.header("Runtime")
+    feed_rate = st.number_input("Feed rate (units/min)", min_value=0.0, value=100.0)
+    path_len = st.number_input("Path length (units)", min_value=0.0, value=200.0)
+    if st.button("Calculate"):
+        try:
+            runtime = calculate_runtime(feed_rate, path_len)
+        except ValueError as exc:
+            st.error(str(exc))
+        else:
+            st.text(f"Estimated runtime: {runtime} minutes")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,17 @@ import sys
 
 def test_cli_runs(tmp_path):
     sample = Path(__file__).parent / "sample.step"
-    cmd = [sys.executable, "-m", "crown_cnc_estimator.cli", str(sample), "--units", "inch", "--material", "1018"]
+    cmd = [
+        sys.executable,
+        "-m",
+        "crown_cnc_estimator.cli",
+        "bounding-box",
+        str(sample),
+        "--units",
+        "inch",
+        "--material",
+        "1018",
+    ]
     result = subprocess.run(cmd, capture_output=True, text=True)
     assert result.returncode == 0
     assert "Material: 1018 steel" in result.stdout

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_interactive_subcommand():
+    sample = Path(__file__).parent / "sample.step"
+    inputs = f"{sample}\nmetric\n6061\n"
+    cmd = [sys.executable, "-m", "crown_cnc_estimator.cli", "interactive"]
+    result = subprocess.run(cmd, input=inputs, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Material: 6061 aluminum" in result.stdout

--- a/tests/test_cli_parse_runtime.py
+++ b/tests/test_cli_parse_runtime.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_parse_step_subcommand():
+    sample = Path(__file__).parent / "sample.step"
+    cmd = [sys.executable, "-m", "crown_cnc_estimator.cli", "parse-step", str(sample)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Entities: 5" in result.stdout
+
+
+def test_runtime_subcommand():
+    cmd = [sys.executable, "-m", "crown_cnc_estimator.cli", "runtime", "100", "200"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Estimated runtime: 2.0 minutes" in result.stdout


### PR DESCRIPTION
## Summary
- create `streamlit_app.py` with a small Streamlit UI
- document the new Streamlit option in the README
- allow parsing STEP files that contain non-UTF‑8 characters

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b35ae307c832cb9bd75250399e723