### PR TITLE
Add volumetric milling runtime estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,23 @@ in `tests/`.
 Calculate runtime:
 
 ```python
-from crown_cnc_estimator import calculate_runtime
+from crown_cnc_estimator import calculate_runtime, estimate_milling_runtime
 
 runtime = calculate_runtime(feed_rate=100, path_length=200)
 print(runtime)  # 2.0 minutes
+
+estimate = estimate_milling_runtime(
+    stock_volume=1_000,
+    part_volume=400,
+    roughing_mrr=10,
+    finishing_volume=60,
+    finishing_mrr=2,
+    drilling_time=5,
+    finishing_adder=1,
+    overhead_time=4,
+)
+print(estimate.minutes_per_part)  # 94.0 minutes
+print(estimate.rough_minutes, estimate.finish_minutes)
 ```
 
 The CLI now organizes features into subcommands.

--- a/crown_cnc_estimator/__init__.py
+++ b/crown_cnc_estimator/__init__.py
@@ -1,8 +1,14 @@
 """Top-level package for Crown CNC Estimator."""
 
-from .runtime import calculate_runtime
+from .runtime import calculate_runtime, estimate_milling_runtime, MillingRuntimeEstimate
 from .step_parser import bounding_box
 
 APP_NAME = "Crown CNC Estimator"
-__all__ = ["calculate_runtime", "bounding_box", "APP_NAME"]
+__all__ = [
+    "calculate_runtime",
+    "estimate_milling_runtime",
+    "MillingRuntimeEstimate",
+    "bounding_box",
+    "APP_NAME",
+]
 __version__ = "0.1.0"

--- a/crown_cnc_estimator/runtime.py
+++ b/crown_cnc_estimator/runtime.py
@@ -1,8 +1,114 @@
-"""Simple runtime calculations."""
+"""Utilities for estimating CNC runtimes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
 
 
 def calculate_runtime(feed_rate: float, path_length: float) -> float:
-    """Return runtime given feed_rate (units/min) and path_length (units)."""
+    """Return runtime given ``feed_rate`` (units/min) and ``path_length`` (units)."""
+
     if feed_rate <= 0:
         raise ValueError("feed_rate must be greater than zero")
     return path_length / feed_rate
+
+
+@dataclass(frozen=True)
+class MillingRuntimeEstimate:
+    """Structured result from :func:`estimate_milling_runtime`."""
+
+    minutes_per_part: float
+    rough_minutes: float
+    finish_minutes: float
+    drilling_minutes: float
+    overhead_minutes: float
+    removal_volume: float
+    effective_mrr: float
+
+
+def estimate_milling_runtime(
+    stock_volume: float,
+    part_volume: float,
+    *,
+    roughing_mrr: float,
+    finishing_volume: float = 0.0,
+    finishing_mrr: float | None = None,
+    drilling_time: float = 0.0,
+    finishing_adder: float = 0.0,
+    overhead_time: float = 0.0,
+) -> MillingRuntimeEstimate:
+    """Estimate CNC milling runtime using a volumetric removal model.
+
+    The calculation follows a "stock minus part equals removal volume" approach.
+    The removal volume is split into roughing and finishing portions.  Roughing
+    time is computed from the remaining material removal rate, and a finishing
+    allowance can be converted to time with ``finishing_mrr``.  Additional time
+    can be added for drilling, finishing passes, and overhead.
+
+    Args:
+        stock_volume: Volume of the starting stock.
+        part_volume: Volume of the finished part.
+        roughing_mrr: Effective material removal rate for roughing (volume/min).
+        finishing_volume: Volume reserved for finishing operations.  Must not
+            exceed the total removal volume.
+        finishing_mrr: Material removal rate for finishing passes.  If omitted
+            the roughing value is reused.
+        drilling_time: Minutes added to account for drilling operations.
+        finishing_adder: Extra finishing time (minutes) in addition to the
+            volumetric allowance.
+        overhead_time: Miscellaneous non-cutting time in minutes.
+
+    Returns:
+        A :class:`MillingRuntimeEstimate` summarising the breakdown.
+
+    Raises:
+        ValueError: If provided volumes or rates are inconsistent.
+    """
+
+    if stock_volume < 0:
+        raise ValueError("stock_volume must be non-negative")
+    if part_volume < 0:
+        raise ValueError("part_volume must be non-negative")
+    if roughing_mrr <= 0:
+        raise ValueError("roughing_mrr must be greater than zero")
+    if finishing_volume < 0:
+        raise ValueError("finishing_volume must be non-negative")
+    if drilling_time < 0:
+        raise ValueError("drilling_time must be non-negative")
+    if finishing_adder < 0:
+        raise ValueError("finishing_adder must be non-negative")
+    if overhead_time < 0:
+        raise ValueError("overhead_time must be non-negative")
+
+    removal_volume = max(stock_volume - part_volume, 0.0)
+    if finishing_volume > removal_volume:
+        raise ValueError("finishing_volume cannot exceed removal_volume")
+
+    finishing_rate = roughing_mrr if finishing_mrr is None else finishing_mrr
+    if finishing_rate <= 0:
+        raise ValueError("finishing_mrr must be greater than zero")
+
+    roughing_volume = removal_volume - finishing_volume
+    rough_minutes = roughing_volume / roughing_mrr if roughing_volume else 0.0
+
+    finishing_minutes = finishing_adder
+    if finishing_volume:
+        finishing_minutes += finishing_volume / finishing_rate
+
+    minutes_per_part = rough_minutes + finishing_minutes + drilling_time + overhead_time
+
+    cutting_minutes = rough_minutes + finishing_minutes
+    if removal_volume and cutting_minutes:
+        effective_mrr = removal_volume / cutting_minutes
+    else:
+        effective_mrr = 0.0
+
+    return MillingRuntimeEstimate(
+        minutes_per_part=minutes_per_part,
+        rough_minutes=rough_minutes,
+        finish_minutes=finishing_minutes,
+        drilling_minutes=drilling_time,
+        overhead_minutes=overhead_time,
+        removal_volume=removal_volume,
+        effective_mrr=effective_mrr,
+    )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,6 +1,10 @@
 import pytest
 
-from crown_cnc_estimator.runtime import calculate_runtime
+from crown_cnc_estimator.runtime import (
+    calculate_runtime,
+    estimate_milling_runtime,
+    MillingRuntimeEstimate,
+)
 from crown_cnc_estimator import APP_NAME
 
 
@@ -22,3 +26,50 @@ def test_calculate_runtime_negative_path_length():
 
 def test_app_name_constant():
     assert APP_NAME == "Crown CNC Estimator"
+
+
+def test_estimate_milling_runtime_breakdown():
+    result = estimate_milling_runtime(
+        stock_volume=1000,
+        part_volume=400,
+        roughing_mrr=10,
+        finishing_volume=60,
+        finishing_mrr=2,
+        drilling_time=5,
+        finishing_adder=1,
+        overhead_time=4,
+    )
+
+    assert isinstance(result, MillingRuntimeEstimate)
+    # Volumetric removal breakdown
+    assert result.removal_volume == pytest.approx(600)
+    assert result.rough_minutes == pytest.approx(54)
+    assert result.finish_minutes == pytest.approx(31)
+    assert result.minutes_per_part == pytest.approx(94)
+    # Effective MRR: total removal divided by cutting time (rough + finish)
+    assert result.effective_mrr == pytest.approx(600 / (54 + 31))
+
+
+def test_estimate_milling_runtime_finishing_volume_guard():
+    with pytest.raises(ValueError):
+        estimate_milling_runtime(
+            stock_volume=100,
+            part_volume=10,
+            roughing_mrr=5,
+            finishing_volume=200,
+        )
+
+
+def test_estimate_milling_runtime_zero_removal():
+    result = estimate_milling_runtime(
+        stock_volume=100,
+        part_volume=100,
+        roughing_mrr=5,
+        drilling_time=2,
+        finishing_adder=0.5,
+    )
+
+    assert result.removal_volume == 0
+    assert result.minutes_per_part == pytest.approx(2.5)
+    assert result.rough_minutes == 0
+    assert result.finish_minutes == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- add an `estimate_milling_runtime` helper that implements a volumetric stock-minus-part removal model with drilling, finishing, and overhead adders
- expose the new API from the package and document its usage in the README
- extend the runtime test suite to validate the new estimator and its edge cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc231078dc832c85a2835055dfc301